### PR TITLE
Use logical and with numpy arrays to be more obvious abouts sizes

### DIFF
--- a/tests/masking/test_mask_transform.py
+++ b/tests/masking/test_mask_transform.py
@@ -104,10 +104,9 @@ def test_merge_masks():
     }
 
     # merge masks
-    final_mask_bytes, class_mask_results = model.merge_masks(grouped_masks, empty_shape)
+    final_mask_np, class_mask_results = model.merge_masks(grouped_masks, empty_shape)
 
     # ensure the function returns a NumPy array
-    final_mask_np = np.load(io.BytesIO(final_mask_bytes))
     assert isinstance(final_mask_np, np.ndarray)
     assert final_mask_np.dtype == np.uint8
     assert final_mask_np.shape == (4, 4)
@@ -118,9 +117,7 @@ def test_merge_masks():
     assert "plant" in class_mask_results
 
     # ensure each mask is a NumPy array of the same shape
-    for mask in class_mask_results.values():
-        assert isinstance(mask, bytes)
-        mask_np = np.load(io.BytesIO(mask))
+    for mask_np in class_mask_results.values():
         assert mask_np.dtype == np.uint8
         assert mask_np.shape == (4, 4)
 


### PR DESCRIPTION
Failing with:

```
ERROR tests/masking/test_mask_workflow.py::test_process_masking - pyspark.errors.exceptions.captured.PythonException: 
  An exception was thrown from the Python worker. Please see the stack trace below.
Traceback (most recent call last):
  File "/storage/home/hcoda1/8/amiyaguchi3/clef/plantclef-2025/plantclef/masking/transform.py", line 202, in predict
    final_mask, class_masks = self.merge_masks(
  File "/storage/home/hcoda1/8/amiyaguchi3/clef/plantclef-2025/plantclef/masking/transform.py", line 180, in merge_masks
    class_masks[class_name] |= mask
ValueError: non-broadcastable output operand with shape (3024,3024) doesn't match the broadcast shape (42,3,3024,3024)
```