### PR TITLE
Use compression by default for masks and fix workflow bugs

### DIFF
--- a/plantclef/embedding/hello_world.py
+++ b/plantclef/embedding/hello_world.py
@@ -2,11 +2,6 @@ import typer
 import logging
 from typing_extensions import Annotated
 
-logging.basicConfig(
-    level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
-
 
 def main(
     input_path: Annotated[str, typer.Argument(help="Input root directory")],
@@ -14,6 +9,11 @@ def main(
     sample_id: Annotated[int, typer.Option(help="Sample ID")] = None,
     scheduler_host: Annotated[str, typer.Option(help="Scheduler host")] = None,
 ):
+    logging.basicConfig(
+        level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+    logger = logging.getLogger(__name__)
+
     logger.info("Starting workflow execution...")
     logger.info(f"Input path: {input_path}")
     logger.info(f"Output path: {output_path}")

--- a/plantclef/embedding/test_workflow.py
+++ b/plantclef/embedding/test_workflow.py
@@ -5,11 +5,6 @@ from typing_extensions import Annotated
 from plantclef.spark import spark_resource
 
 
-logging.basicConfig(level=logging.INFO)
-
-logger = logging.getLogger(__name__)
-
-
 class ProcessTest(luigi.Task):
     """Task to process embeddings."""
 
@@ -25,9 +20,9 @@ class ProcessTest(luigi.Task):
             with spark_resource() as spark:
                 df = spark.read.parquet(self.input_path)
                 df.printSchema()  # This should print, but may be suppressed
-                logger.info("Schema printed successfully")
+                logging.info("Schema printed successfully")
         except Exception as e:
-            logger.error(f"Spark job failed: {e}")
+            logging.error(f"Spark job failed: {e}")
 
 
 class Workflow(luigi.WrapperTask):
@@ -44,12 +39,12 @@ class Workflow(luigi.WrapperTask):
         else:
             sample_ids = list(range(self.num_tasks))
 
-        logger.info("Creating tasks...")
-        logger.info(f"Sample IDs: {sample_ids}")
+        logging.info("Creating tasks...")
+        logging.info(f"Sample IDs: {sample_ids}")
 
         tasks = []
         for sample_id in sample_ids:
-            logger.info(f"Creating task for sample_id: {sample_id}")
+            logging.info(f"Creating task for sample_id: {sample_id}")
             task = ProcessTest(
                 input_path=self.input_path,
                 output_path=self.output_path,
@@ -66,6 +61,9 @@ def main(
     sample_id: Annotated[int, typer.Option(help="Sample ID")] = None,
     scheduler_host: Annotated[str, typer.Option(help="Scheduler host")] = None,
 ):
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
     logger.info("Starting workflow execution...")
     logger.info(f"Input path: {input_path}")
     logger.info(f"Output path: {output_path}")

--- a/plantclef/masking/params.py
+++ b/plantclef/masking/params.py
@@ -43,25 +43,3 @@ class HasCheckpointPathGroundingDINO(Param):
 
     def getCheckpointPathGroundingDINO(self) -> str:
         return self.getOrDefault(self.checkpointPathGroundingDINO)
-
-
-class HasBatchSize(Param):
-    """
-    Mixin for param batch_size: int
-    """
-
-    batchSize = Param(
-        Params._dummy(),
-        "batchSize",
-        "The batch size to use for embedding extraction",
-        typeConverter=TypeConverters.toInt,
-    )
-
-    def __init__(self):
-        super().__init__(
-            default=32,
-            doc="The batch size to use for embedding extraction",
-        )
-
-    def getBatchSize(self) -> int:
-        return self.getOrDefault(self.batchSize)

--- a/plantclef/masking/workflow.py
+++ b/plantclef/masking/workflow.py
@@ -126,7 +126,7 @@ class Workflow(luigi.WrapperTask):
         if self.sample_id is not None:
             sample_ids = [self.sample_id]
         else:
-            sample_ids = list(range(self.num_tasks))
+            sample_ids = list(range(self.num_sample_ids))
 
         tasks = []
         for sample_id in sample_ids:
@@ -148,6 +148,7 @@ def main(
     cpu_count: Annotated[int, typer.Option(help="Number of CPUs")] = 8,
     sample_id: Annotated[int, typer.Option(help="Sample ID")] = None,
     num_sample_ids: Annotated[int, typer.Option(help="Number of sample IDs")] = 20,
+    num_partitions: Annotated[int, typer.Option(help="Number of partitions")] = 20,
     scheduler_host: Annotated[str, typer.Option(help="Scheduler host")] = None,
 ):
     # run the workflow
@@ -165,6 +166,7 @@ def main(
                 cpu_count=cpu_count,
                 num_sample_ids=num_sample_ids,
                 sample_id=sample_id,
+                num_partitions=num_partitions,
             )
         ],
         **kwargs,

--- a/plantclef/masking/workflow.py
+++ b/plantclef/masking/workflow.py
@@ -17,7 +17,6 @@ class ProcessMasking(luigi.Task):
     input_path = luigi.Parameter()
     output_path = luigi.Parameter()
     cpu_count = luigi.IntParameter(default=4)
-    batch_size = luigi.IntParameter(default=32)
     num_partitions = luigi.OptionalIntParameter(default=20)
     # we break the dataset into a number of samples that are processed in parallel
     sample_col = luigi.Parameter(default="image_name")
@@ -47,7 +46,6 @@ class ProcessMasking(luigi.Task):
                     output_col="masks",
                     checkpoint_path_sam=self.checkpoint_path_sam,
                     checkpoint_path_groundingdino=self.checkpoint_path_groundingdino,
-                    batch_size=self.batch_size,
                 ),
                 SQLTransformer(statement=self.sql_statement),
             ]
@@ -121,7 +119,6 @@ class Workflow(luigi.WrapperTask):
     sample_id = luigi.OptionalParameter()
     num_sample_ids = luigi.IntParameter(default=20)
     cpu_count = luigi.IntParameter(default=6)
-    batch_size = luigi.IntParameter(default=32)
     num_partitions = luigi.IntParameter(default=20)
 
     def requires(self):
@@ -137,7 +134,6 @@ class Workflow(luigi.WrapperTask):
                 input_path=self.input_path,
                 output_path=self.output_path,
                 cpu_count=self.cpu_count,
-                batch_size=self.batch_size,
                 num_partitions=self.num_partitions,
                 sample_id=sample_id,
                 num_sample_ids=self.num_sample_ids,
@@ -150,7 +146,6 @@ def main(
     input_path: Annotated[str, typer.Argument(help="Input root directory")],
     output_path: Annotated[str, typer.Argument(help="Output root directory")],
     cpu_count: Annotated[int, typer.Option(help="Number of CPUs")] = 8,
-    batch_size: Annotated[int, typer.Option(help="Batch size")] = 32,
     sample_id: Annotated[int, typer.Option(help="Sample ID")] = None,
     num_sample_ids: Annotated[int, typer.Option(help="Number of sample IDs")] = 20,
     scheduler_host: Annotated[str, typer.Option(help="Scheduler host")] = None,
@@ -168,7 +163,6 @@ def main(
                 input_path=input_path,
                 output_path=output_path,
                 cpu_count=cpu_count,
-                batch_size=batch_size,
                 num_sample_ids=num_sample_ids,
                 sample_id=sample_id,
             )

--- a/plantclef/model_setup.py
+++ b/plantclef/model_setup.py
@@ -22,6 +22,7 @@ def get_scratch_model_dir() -> str:
 def setup_fine_tuned_model(
     scratch_model: bool = True,
     use_only_classifier: bool = False,
+    ensure_model_exists: bool = False,
 ):
     """
     Downloads and unzips a model from PACE and returns the path to the specified model file.
@@ -44,7 +45,7 @@ def setup_fine_tuned_model(
     full_model_path = os.path.join(model_base_path, relative_model_path)
 
     # Check if the model file exists
-    if not os.path.exists(full_model_path):
+    if not os.path.exists(full_model_path) and ensure_model_exists:
         raise FileNotFoundError(f"Model file not found at: {full_model_path}")
 
     # Return the path to the model file
@@ -61,60 +62,7 @@ def download_file(url, dest_path):
     print(f"Downloaded {url} to {dest_path}")
 
 
-def setup_segment_anything_checkpoint_path():
-    home_dir = Path(os.path.expanduser("~"))
-    checkpoint_dir = os.path.join(home_dir, "scratch/plantclef/SAM_checkpoint/weights")
-    os.makedirs(checkpoint_dir, exist_ok=True)
-    sam_checkpoint_path = os.path.join(checkpoint_dir, "sam_vit_h_4b8939.pth")
-
-    if not os.path.exists(sam_checkpoint_path):
-        sam_url = "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth"
-        print("SAM checkpoint not found. Downloading...")
-        download_file(sam_url, sam_checkpoint_path)
-
-    return sam_checkpoint_path
-
-
-def setup_groundingdino_checkpoint_path():
-    home_dir = Path(os.path.expanduser("~"))
-    checkpoint_dir = os.path.join(
-        home_dir, "scratch/plantclef/groundingdino/checkpoint/weights"
-    )
-    os.makedirs(checkpoint_dir, exist_ok=True)
-    grounding_dino_checkpoint_path = os.path.join(
-        checkpoint_dir, "groundingdino_swint_ogc.pth"
-    )
-
-    if not os.path.exists(grounding_dino_checkpoint_path):
-        groundingdino_url = "https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth"
-        print("GroundingDINO checkpoint not found. Downloading...")
-        download_file(groundingdino_url, grounding_dino_checkpoint_path)
-
-    return grounding_dino_checkpoint_path
-
-
-def setup_groundingdino_config_path():
-    home_dir = Path(os.path.expanduser("~"))
-    config_dir = os.path.join(
-        home_dir,
-        "scratch/plantclef/Grounded-Segment-Anything/GroundingDINO/groundingdino/config/GroundingDINO_SwinT_OGC.py",
-    )
-    return config_dir
-
-
 if __name__ == "__main__":
     # Get model
     dino_model_path = setup_fine_tuned_model()
     print("Model path:", dino_model_path)
-
-    # Get SAM checkpoint path
-    sam_checkpoint_path = setup_segment_anything_checkpoint_path()
-    print("SAM checkpoint path:", sam_checkpoint_path)
-
-    # Get GroundingDINO checkpoint path
-    grounding_dino_checkpoint_path = setup_groundingdino_checkpoint_path()
-    print("GroundingDINO checkpoint path:", grounding_dino_checkpoint_path)
-
-    # Get GroundingDINO config path
-    grounding_dino_config_path = setup_groundingdino_config_path()
-    print("GroundingDINO config path:", grounding_dino_config_path)

--- a/plantclef/plotting.py
+++ b/plantclef/plotting.py
@@ -1,10 +1,10 @@
-import io
 import math
 import textwrap
 
 import matplotlib.pyplot as plt
 import numpy as np
 from PIL import Image
+from .serde import deserialize_image, deserialize_mask
 
 
 def plot_images_from_binary(
@@ -43,7 +43,7 @@ def plot_images_from_binary(
 
     for ax, binary_data, name in zip(axes, image_data_list, image_names):
         # Convert binary data to an image and display it
-        image = Image.open(io.BytesIO(binary_data))
+        image = deserialize_image(binary_data)
 
         # Crop image to square if required
         if crop_square:
@@ -173,9 +173,9 @@ def plot_masks_from_binary(
         axes, image_data, mask_image_data, image_names
     ):
         # Convert binary data to an image
-        image = Image.open(io.BytesIO(binary_data))
+        image = deserialize_image(binary_data)
         image_array = np.array(image)
-        mask_array = np.load(io.BytesIO(mask_binary_data))
+        mask_array = deserialize_mask(mask_binary_data)
         mask_array = np.expand_dims(mask_array, axis=-1)
         mask_array = np.repeat(mask_array, 3, axis=-1)
         mask_img = image_array * mask_array
@@ -231,13 +231,11 @@ def plot_individual_masks_comparison(
 
     for row_idx, row in enumerate(subset_df):
         # load original image
-        image = Image.open(io.BytesIO(row["data"])).convert("RGB")
+        image = deserialize_image(row["data"]).convert("RGB")
         image_array = np.array(image)
 
         # Load masks
-        masks = {
-            mask_name: np.load(io.BytesIO(row[mask_name])) for mask_name in mask_names
-        }
+        masks = {mask_name: np.load((row[mask_name])) for mask_name in mask_names}
 
         # Expand masks to match image dimensions
         masks_rgb = {

--- a/plantclef/serde.py
+++ b/plantclef/serde.py
@@ -19,14 +19,18 @@ def serialize_image(image: Image.Image) -> bytes:
     return buffer.getvalue()
 
 
-def deserialize_mask(bytes: bytes) -> np.ndarray:
+def deserialize_mask(bytes: bytes, use_compression=True) -> np.ndarray:
     """Decode the numpy mask array from raw bytes using np.load()."""
-    buffer = io.BytesIO(zlib.decompress(bytes))
-    return np.load(buffer)
+    if use_compression:
+        bytes = zlib.decompress(bytes)
+    return np.load(io.BytesIO(bytes))
 
 
-def serialize_mask(mask: np.ndarray) -> bytes:
+def serialize_mask(mask: np.ndarray, use_compression=True) -> bytes:
     """Encode the numpy mask array as raw bytes using np.save()."""
     buffer = io.BytesIO()
     np.save(buffer, mask)
-    return zlib.compress(buffer.getvalue())
+    value = buffer.getvalue()
+    if use_compression:
+        value = zlib.compress(value)
+    return value

--- a/plantclef/serde.py
+++ b/plantclef/serde.py
@@ -1,0 +1,32 @@
+"""Module for encoding and decoding data structures to and from raw bytes"""
+
+from PIL import Image
+import numpy as np
+import zlib
+import io
+
+
+def deserialize_image(bytes: bytes) -> Image.Image:
+    """Decode the image from raw bytes using PIL."""
+    buffer = io.BytesIO(bytes)
+    return Image.open(buffer)
+
+
+def serialize_image(image: Image.Image) -> bytes:
+    """Encode the image as raw bytes using PIL."""
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def deserialize_mask(bytes: bytes) -> np.ndarray:
+    """Decode the numpy mask array from raw bytes using np.load()."""
+    buffer = io.BytesIO(zlib.decompress(bytes))
+    return np.load(buffer)
+
+
+def serialize_mask(mask: np.ndarray) -> bytes:
+    """Encode the numpy mask array as raw bytes using np.save()."""
+    buffer = io.BytesIO()
+    np.save(buffer, mask)
+    return zlib.compress(buffer.getvalue())

--- a/plantclef/spark.py
+++ b/plantclef/spark.py
@@ -16,6 +16,7 @@ def get_spark(
     executor_memory=os.environ.get("PYSPARK_EXECUTOR_MEMORY", "1g"),
     local_dir=os.environ.get("SPARK_LOCAL_DIR", "/tmp"),
     app_name="clef",
+    log_level="ERROR",
     **kwargs,
 ):
     """Get a spark session for a single driver."""
@@ -31,7 +32,9 @@ def get_spark(
     )
     for k, v in kwargs.items():
         builder = builder.config(k, v)
-    return builder.appName(app_name).master(f"local[{cores}]").getOrCreate()
+    spark = builder.appName(app_name).master(f"local[{cores}]").getOrCreate()
+    spark.sparkContext.setLogLevel(log_level)
+    return spark
 
 
 @contextmanager

--- a/scripts/nvidia-logs.sh
+++ b/scripts/nvidia-logs.sh
@@ -52,13 +52,17 @@ def parse(input: str):
     spark = SparkSession.builder.appName("nvidia-logs").getOrCreate()
     spark.conf.set("spark.sql.legacy.timeParserPolicy", "LEGACY")
 
-    df = spark.read.json(input)
-    sub = df.select(
-        F.unix_timestamp("nvidia_smi_log.timestamp", "EEE MMM dd HH:mm:ss yyyy").alias("timestamp"),
-        "nvidia_smi_log.gpu.product_name",
-        "nvidia_smi_log.gpu.utilization",
-        "nvidia_smi_log.gpu.processes.process_info",
-    ).orderBy(F.desc("timestamp"))
+    try:
+        df = spark.read.json(input)
+        sub = df.select(
+            F.unix_timestamp("nvidia_smi_log.timestamp", "EEE MMM dd HH:mm:ss yyyy").alias("timestamp"),
+            "nvidia_smi_log.gpu.product_name",
+            "nvidia_smi_log.gpu.utilization",
+            "nvidia_smi_log.gpu.processes.process_info",
+        ).orderBy(F.desc("timestamp"))
+    except:
+        print("Error reading JSON file. Please ensure the file is in the correct format.", flush=True)
+        return
 
     gpu_name = sub.first().product_name
 

--- a/scripts/slurm-alloc.py
+++ b/scripts/slurm-alloc.py
@@ -28,12 +28,12 @@ cmd = [
     f"--account={args.account}",
     "--nodes=1",
     "--ntasks=1",
-    "--cpus-per-task=4",
-    "--time=1:00:00",
+    "--cpus-per-task=8",
+    "--time=2:00:00",
     "--qos=inferno",
 ]
 if args.gpu:
-    cmd += ["--gres=gpu:v100:1"]
+    cmd += ["--gres=gpu:1", "-C=RTX6000"]
 cmd += ["--mem-per-gpu=32G" if args.gpu else "--mem-per-cpu=4G"]
 cmd = " ".join(cmd)
 print(cmd)

--- a/tests/masking/test_mask_transform.py
+++ b/tests/masking/test_mask_transform.py
@@ -1,7 +1,6 @@
-import io
 import numpy as np
-from PIL import Image
 from plantclef.masking.transform import WrappedMasking
+from plantclef.serde import deserialize_mask, deserialize_image
 
 
 def test_wrapped_mask_detect(test_image):
@@ -65,8 +64,8 @@ def test_wrapped_mask(spark_df):
     assert isinstance(row.masks["leaf_mask"], bytearray)
 
     # decode the bytes back into a NumPy array
-    mask = np.load(io.BytesIO(row.masks["leaf_mask"]))
-    rock_mask = np.load(io.BytesIO(row.masks["rock_mask"]))
+    mask = deserialize_mask(row.masks["leaf_mask"])
+    rock_mask = deserialize_mask(row.masks["rock_mask"])
 
     # ensure the mask is a NumPy array
     assert isinstance(mask, np.ndarray)
@@ -76,7 +75,7 @@ def test_wrapped_mask(spark_df):
 
     # ensure mask has the expected dimensions (same as input image)
     img_data = spark_df.select("data").first().data
-    img = Image.open(io.BytesIO(img_data))
+    img = deserialize_image(img_data)
     expected_shape = img.size[::-1]
     assert mask.shape == expected_shape
 

--- a/user/acmiyaguchi/masking.sbatch
+++ b/user/acmiyaguchi/masking.sbatch
@@ -1,0 +1,34 @@
+#!/bin/bash
+#SBATCH --job-name=plantclef-mask --account=paceship-dsgt_clef2025
+#SBATCH --nodes=1 --gres=gpu:1 -C RTX6000 --cpus-per-task=6 --mem-per-gpu=64G
+#SBATCH --time=6:00:00 --qos=inferno
+#SBATCH --output=Report-%j.log --mail-type=END,FAIL --mail-user=acmiyaguchi@gatech.edu
+
+set -xe
+echo "Job ID: $SLURM_JOB_ID"
+echo "Hostname: $(hostname)"
+echo "Number of CPUs: $(nproc)"
+echo "Available memory: $(free -h)"
+
+# activate the environment
+source ~/clef/plantclef-2025/scripts/activate.sh
+nvidia-smi
+
+# start the nvidia monitoring job in the background using SLURM job id
+NVIDIA_LOG_FILE=Report-${SLURM_JOB_ID}-nvidia-logs.ndjson
+python ~/clef/plantclef-2025/scripts/nvidia-logs.sh monitor "$NVIDIA_LOG_FILE" --interval 15 &
+nvidia_logs_pid=$!
+echo "Started NVIDIA monitoring process with PID ${nvidia_logs_pid}"
+
+scratch_data_dir=$(realpath ~/scratch/plantclef/data)
+project_data_dir=/storage/coda1/p-dsgt_clef2025/0/shared/plantclef/data
+dataset_name=test_2024_dev_anthony
+plantclef masking workflow \
+    $project_data_dir/parquet/$dataset_name \
+    $scratch_data_dir/masking/${dataset_name} \
+    --cpu-count 2 \
+    --num-sample-ids 20 \
+    --num-partitions 5
+
+# parse the nvida monitoring output
+python ~/clef/plantclef-2025/scripts/nvidia-logs.sh parse Report-${SLURM_JOB_ID}-nvidia-logs.ndjson

--- a/user/acmiyaguchi/masking.sbatch
+++ b/user/acmiyaguchi/masking.sbatch
@@ -4,7 +4,6 @@
 #SBATCH --time=6:00:00 --qos=inferno
 #SBATCH --output=Report-%j.log --mail-type=END,FAIL --mail-user=acmiyaguchi@gatech.edu
 
-set -xe
 echo "Job ID: $SLURM_JOB_ID"
 echo "Hostname: $(hostname)"
 echo "Number of CPUs: $(nproc)"
@@ -12,6 +11,8 @@ echo "Available memory: $(free -h)"
 
 # activate the environment
 source ~/clef/plantclef-2025/scripts/activate.sh
+
+set -xe
 nvidia-smi
 
 # start the nvidia monitoring job in the background using SLURM job id
@@ -22,10 +23,9 @@ echo "Started NVIDIA monitoring process with PID ${nvidia_logs_pid}"
 
 scratch_data_dir=$(realpath ~/scratch/plantclef/data)
 project_data_dir=/storage/coda1/p-dsgt_clef2025/0/shared/plantclef/data
-dataset_name=test_2024_dev_anthony
 plantclef masking workflow \
-    $project_data_dir/parquet/$dataset_name \
-    $scratch_data_dir/masking/${dataset_name} \
+    $project_data_dir/parquet/test_2024 \
+    $scratch_data_dir/masking/test_2024_dev_anthony \
     --cpu-count 2 \
     --num-sample-ids 20 \
     --num-partitions 5


### PR DESCRIPTION
The parquet files for 20 images is unusually slow, and this is probably because each mask is 9mb. Compression brings this down to 43k, which is 2 orders of magnitude.