### PR TITLE
Simplify embed workflow to use unpivoted masks

### DIFF
--- a/plantclef/retrieval/embed/__init__.py
+++ b/plantclef/retrieval/embed/__init__.py
@@ -1,7 +1,8 @@
 import typer
-from .workflow import main as workflow_main
+from .workflow import embed, embed_with_mask
 from .mask.workflow import filter_by_mask
 
 app = typer.Typer()
-app.command("workflow")(workflow_main)
+app.command("workflow")(embed)
 app.command("filter-by-mask")(filter_by_mask)
+app.command("workflow-with-mask")(embed_with_mask)

--- a/plantclef/retrieval/embed/transform.py
+++ b/plantclef/retrieval/embed/transform.py
@@ -1,12 +1,12 @@
+import io
+
 import timm
 import torch
+from PIL import Image
 from plantclef.model_setup import setup_fine_tuned_model
-from plantclef.serde import deserialize_image
-
-from .params import HasModelName, HasModelPath, HasBatchSize
-
+from plantclef.embedding.transform import HasModelPath, HasModelName
 from pyspark.ml import Transformer
-from pyspark.ml.param.shared import HasInputCols, HasOutputCols
+from pyspark.ml.param.shared import HasInputCol, HasOutputCol
 from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
@@ -15,11 +15,10 @@ from pyspark.sql.types import ArrayType, FloatType
 
 class EmbedderFineTunedDINOv2(
     Transformer,
-    HasInputCols,
-    HasOutputCols,
+    HasInputCol,
+    HasOutputCol,
     HasModelPath,
     HasModelName,
-    HasBatchSize,
     DefaultParamsReadable,
     DefaultParamsWritable,
 ):
@@ -29,20 +28,19 @@ class EmbedderFineTunedDINOv2(
 
     def __init__(
         self,
-        input_cols: list = ["leaf_mask", "flower_mask", "plant_mask"],
-        output_cols: list = ["leaf_embed", "flower_embed", "plant_embed"],
+        input_col: str = "input",
+        output_col: str = "output",
         model_path: str = setup_fine_tuned_model(),
         model_name: str = "vit_base_patch14_reg4_dinov2.lvd142m",
-        batch_size: int = 8,
-        grid_size: int = 4,
+        use_grid: bool = False,
+        grid_size: int = 3,
     ):
         super().__init__()
         self._setDefault(
-            inputCols=input_cols,
-            outputCols=output_cols,
+            inputCol=input_col,
+            outputCol=output_col,
             modelPath=model_path,
             modelName=model_name,
-            batchSize=batch_size,
         )
         self.num_classes = 7806  # total number of plant species
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -60,20 +58,8 @@ class EmbedderFineTunedDINOv2(
         # Move model to GPU if available
         self.model.to(self.device)
         self.model.eval()
+        self.use_grid = use_grid
         self.grid_size = grid_size
-
-    # def _split_into_grid(self, mask_array):
-    #     """Splits the numpy mask array into grid tiles."""
-    #     h, w = mask_array.shape
-    #     grid_h, grid_w = h // self.grid_size, w // self.grid_size
-    #     tiles = []
-    #     for i in range(self.grid_size):
-    #         for j in range(self.grid_size):
-    #             tile = mask_array[
-    #                 i * grid_h : (i + 1) * grid_h, j * grid_w : (j + 1) * grid_w
-    #             ]
-    #             tiles.append(tile)
-    #     return tiles
 
     def _split_into_grid(self, image):
         w, h = image.size
@@ -108,18 +94,15 @@ class EmbedderFineTunedDINOv2(
         self._nvidia_smi()
 
         def predict(input_data):
-            # # TODO: remove this print statement, debugging only
-            # print(f"[DEBUG] input type: {type(input_data)}", flush=True)
-            img = deserialize_image(input_data)  # Image.Image
-            # print(f"[DEBUG] img_array shape: {img.size}", flush=True)
-            # print(f"[DEBUG] img_array type: {type(img)}", flush=True)
-
-            tiles = self._split_into_grid(img)
+            img = Image.open(io.BytesIO(input_data))
+            images = [img]
+            if self.use_grid:
+                images = self._split_into_grid(img)
             results = []
-            for tile in tiles:
-                processed_tile = self.transforms(tile).unsqueeze(0).to(self.device)
+            for tile in images:
+                processed_image = self.transforms(tile).unsqueeze(0).to(self.device)
                 with torch.no_grad():
-                    features = self.model.forward_features(processed_tile)
+                    features = self.model.forward_features(processed_image)
                     cls_token = features[:, 0, :].squeeze(0)
                 cls_embeddings = cls_token.cpu().numpy().tolist()
                 results.append(cls_embeddings)
@@ -130,23 +113,14 @@ class EmbedderFineTunedDINOv2(
     def _transform(self, df: DataFrame):
         predict_fn = self._make_predict_fn()
         predict_udf = F.udf(predict_fn, ArrayType(ArrayType(FloatType())))
-        # retrieve embeddings for each input column
-        for idx, (input_col, output_col) in enumerate(
-            zip(self.getInputCols(), self.getOutputCols())
-        ):
-            intermediate_col = f"all_{output_col}"
-            df = df.withColumn(intermediate_col, predict_udf(F.col(input_col))).drop(
-                input_col
-            )
-            # explode embeddings so that each row has a single tile embedding
-            if idx == 0:  # only explode the tile column once
-                df = df.selectExpr(
-                    "*", f"posexplode({intermediate_col}) as (tile, {output_col})"
-                )
-            else:
-                df = df.selectExpr(
-                    "*", f"posexplode({intermediate_col}) as (tmp_tile, {output_col})"
-                )
-                df = df.drop(intermediate_col).drop("tmp_tile")
+        intermediate_col = "all_" + self.getOutputCol()
+        df = df.withColumn(
+            intermediate_col, predict_udf(F.col(self.getInputCol()))
+        ).drop(self.getInputCol())
+
+        # explode embeddings so that each row has a single tile embedding
+        df = df.selectExpr(
+            "*", f"posexplode({intermediate_col}) as (tile, {self.getOutputCol()})"
+        ).drop(intermediate_col)
 
         return df

--- a/plantclef/retrieval/embed/workflow.py
+++ b/plantclef/retrieval/embed/workflow.py
@@ -23,7 +23,6 @@ class ProcessEmbeddings(luigi.Task):
 
     input_path = luigi.Parameter()
     output_path = luigi.Parameter()
-    test_data_path = luigi.Parameter()
     cpu_count = luigi.IntParameter(default=4)
     batch_size = luigi.IntParameter(default=32)
     num_partitions = luigi.OptionalIntParameter(default=20)
@@ -35,8 +34,11 @@ class ProcessEmbeddings(luigi.Task):
     # of tasks that we have in parallel to best take advantage of disk
     model_path = luigi.Parameter(default=setup_fine_tuned_model(scratch_model=True))
     model_name = luigi.Parameter(default="vit_base_patch14_reg4_dinov2.lvd142m")
-    grid_size = luigi.IntParameter(default=4)
-    mask_cols = luigi.ListParameter(default=["leaf_mask", "flower_mask", "plant_mask"])
+    use_grid = luigi.BoolParameter(default=True)
+    grid_size = luigi.IntParameter(default=3)
+    sql_statement = luigi.Parameter(
+        default="SELECT image_name, tile, cls_embedding FROM __THIS__"
+    )
 
     def output(self):
         # write a partitioned dataset to disk
@@ -48,11 +50,11 @@ class ProcessEmbeddings(luigi.Task):
         model = Pipeline(
             stages=[
                 EmbedderFineTunedDINOv2(
-                    input_cols=self.input_columns,
-                    output_cols=self.feature_columns,
+                    input_col="data",
+                    output_col="cls_embedding",
                     model_path=self.model_path,
                     model_name=self.model_name,
-                    batch_size=self.batch_size,
+                    use_grid=self.use_grid,
                     grid_size=self.grid_size,
                 ),
                 SQLTransformer(statement=self.sql_statement),
@@ -61,27 +63,62 @@ class ProcessEmbeddings(luigi.Task):
         return model
 
     @property
-    def input_columns(self) -> list:
-        # input cols that will be used by the transformation
-        input_cols = self.mask_cols
-        if len(self.mask_cols) == 0:
-            input_cols = ["data"]
-        return input_cols
-
-    @property
     def feature_columns(self) -> list:
-        # feature cols that will be created by the transformation
-        feature_cols = [col.replace("mask", "embed") for col in self.mask_cols]
-        if len(self.mask_cols) == 0:
-            feature_cols = ["cls_embedding"]
-        return feature_cols
+        return ["cls_embedding"]
 
-    @property
-    def sql_statement(self) -> str:
-        mask_cols = self.feature_columns
-        mask_cols_str = ", ".join(mask_cols)
-        sql_statement = f"SELECT image_name, tile, {mask_cols_str} FROM __THIS__"
-        return sql_statement
+    def transform(self, model, df, features) -> DataFrame:
+        transformed = model.transform(df)
+
+        for c in features:
+            # check if the feature is a vector and convert it to an array
+            if "array" in transformed.schema[c].simpleString():
+                continue
+            transformed = transformed.withColumn(c, vector_to_array(F.col(c)))
+        return transformed
+
+    def run(self):
+        kwargs = {
+            "cores": self.cpu_count,
+        }
+        with spark_resource(**kwargs) as spark:
+            # read the data and keep the sample we're currently processing
+            df = (
+                spark.read.parquet(self.input_path)
+                .withColumn(
+                    "sample_id",
+                    F.crc32(F.col(self.sample_col).cast("string"))
+                    % self.num_sample_ids,
+                )
+                .where(F.col("sample_id") == self.sample_id)
+                .drop("sample_id")
+            )
+
+            # create the pipeline model
+            pipeline_model = self.pipeline().fit(df)
+
+            # transform the dataframe and write to disk
+            transformed = self.transform(pipeline_model, df, self.feature_columns)
+
+            transformed.printSchema()
+            transformed.explain()
+            (
+                transformed.repartition(self.num_partitions)
+                .cache()
+                .write.mode("overwrite")
+                .parquet(f"{self.output_path}/sample_id={self.sample_id}")
+            )
+
+
+class ProcessEmbeddingsWithMask(ProcessEmbeddings):
+    """Task to process embeddings."""
+
+    input_path = luigi.Parameter()
+    output_path = luigi.Parameter()
+    test_data_path = luigi.Parameter()
+    mask_cols = luigi.ListParameter(default=["leaf_mask", "flower_mask", "plant_mask"])
+    sql_statement = luigi.Parameter(
+        default="SELECT image_name, tile, mask_type, cls_embedding FROM __THIS__"
+    )
 
     @staticmethod
     def apply_overlay(image_bytes: bytes, mask_bytes: bytes) -> bytes:
@@ -102,7 +139,8 @@ class ProcessEmbeddings(luigi.Task):
         print("mask_array shape:", mask_array.shape)
         print("mask type:", type(mask_array))
         # apply overlay
-        overlay_img = image_array * mask_array
+        overlay_img = image_array.copy()
+        overlay_img[mask_array == 0] = 0
         print("overlay_img shape:", overlay_img.shape)
         print("overlay_img type:", type(overlay_img))
         # convert back to bytes
@@ -114,64 +152,17 @@ class ProcessEmbeddings(luigi.Task):
 
         return overlay_bytes
 
-    def transform(self, model, mask_df, test_df, features, mask_cols) -> DataFrame:
-        """Transform the dataframe by applying the model and overlaying the masks."""
-
-        # join the dataframes
-        df = mask_df.join(test_df, on="image_name", how="inner")
-
-        # apply overlay transformation to mask columns
-        if self.input_columns != ["data"]:
-            overlay_udf = F.udf(self.apply_overlay, BinaryType())
-            for mask_col in self.input_columns:
-                overlay_col = mask_col.replace("mask", "overlay")
-                # TODO: remove this print statement, debugging only
-                print("[DEBUG] Applying overlay transformation")
-                print(f"Input cols: {mask_col}, {overlay_col}", flush=True)
-
-                df = df.withColumn(
-                    overlay_col,
-                    overlay_udf(F.col("data"), F.col(mask_col)),
-                )
-            # TODO: remove this print statement, debugging only
-            print("Joined Dataframe:")
-            df.printSchema()
-            # leaf_overlay = df.select("leaf_overlay").first().leaf_overlay
-            # print(f"leaf_overlay type: {type(leaf_overlay)}")
-
-            # # ensure that the output mask is a NumPy array
-            # assert isinstance(leaf_overlay, bytearray)
-
-            # # decode the bytes back into a NumPy array
-            # mask = deserialize_image(leaf_overlay)
-            # assert isinstance(mask, Image.Image)
-
-        # ensure mask has the expected dimensions (same as input image)
-        img_data = df.select("data").first().data
-        img = deserialize_image(img_data)
-        expected_shape = img.size[::-1]
-        print(f"img shape: {expected_shape}")
-        # mask = np.array(mask)
-        # print(f"mask shape: {mask.shape}")
-
-        # run model pipeline
-        transformed = model.transform(df)
-
-        for c in self.feature_columns:
-            # check if the feature is a vector and convert it to an array
-            if "array" in transformed.schema[c].simpleString():
-                continue
-            transformed = transformed.withColumn(c, vector_to_array(F.col(c)))
-        return transformed
-
     def run(self):
-        kwargs = {
-            "cores": self.cpu_count,
-        }
+        kwargs = {"cores": self.cpu_count}
         with spark_resource(**kwargs) as spark:
-            # read the data and keep the sample we're currently processing
+            mask_df = spark.read.parquet(self.input_path)
             mask_df = (
-                spark.read.parquet(self.input_path)
+                mask_df.unpivot(
+                    "image_name",
+                    [c for c in mask_df.columns if "mask" in c],
+                    "mask_type",
+                    "mask",
+                )
                 .withColumn(
                     "sample_id",
                     F.crc32(F.col(self.sample_col).cast("string"))
@@ -180,16 +171,21 @@ class ProcessEmbeddings(luigi.Task):
                 .where(F.col("sample_id") == self.sample_id)
                 .drop("sample_id")
             )
-            # read test data
             test_df = spark.read.parquet(self.test_data_path)
+            df = test_df.join(mask_df, on="image_name", how="inner")
+
+            apply_overlay_udf = F.udf(
+                ProcessEmbeddingsWithMask.apply_overlay, returnType=BinaryType()
+            )
+            df = df.withColumn(
+                "data", apply_overlay_udf(F.col("data"), F.col("mask"))
+            ).drop("mask")
 
             # create the pipeline model
-            pipeline_model = self.pipeline().fit(mask_df)
+            pipeline_model = self.pipeline().fit(df)
 
             # transform the dataframe and write to disk
-            transformed = self.transform(
-                pipeline_model, mask_df, test_df, self.feature_columns, self.mask_cols
-            )
+            transformed = self.transform(pipeline_model, df, self.feature_columns)
 
             transformed.printSchema()
             transformed.explain()
@@ -201,36 +197,7 @@ class ProcessEmbeddings(luigi.Task):
             )
 
 
-class Workflow(luigi.Task):
-    """Workflow with one task."""
-
-    input_path = luigi.Parameter()
-    output_path = luigi.Parameter()
-    test_data_path = luigi.Parameter()
-    sample_id = luigi.OptionalParameter()
-    num_sample_ids = luigi.IntParameter(default=20)
-    cpu_count = luigi.IntParameter(default=6)
-    batch_size = luigi.IntParameter(default=32)
-    grid_size = luigi.IntParameter(default=4)  # 4x4 grid
-    mask_cols = luigi.ListParameter(default=["leaf_mask", "flower_mask", "plant_mask"])
-    num_partitions = luigi.IntParameter(default=10)
-
-    def requires(self):
-        task = ProcessEmbeddings(
-            input_path=self.input_path,
-            output_path=self.output_path,
-            test_data_path=self.test_data_path,
-            cpu_count=self.cpu_count,
-            batch_size=self.batch_size,
-            sample_id=0,
-            num_sample_ids=1,
-            grid_size=self.grid_size,
-            num_partitions=self.num_partitions,
-        )
-        yield task
-
-
-def main(
+def embed(
     input_path: Annotated[str, typer.Argument(help="Input root directory")],
     output_path: Annotated[str, typer.Argument(help="Output root directory")],
     test_data_path: Annotated[str, typer.Argument(help="Test DataFrame directory")],
@@ -251,14 +218,51 @@ def main(
 
     luigi.build(
         [
-            Workflow(
+            ProcessEmbeddings(
                 input_path=input_path,
                 output_path=output_path,
                 test_data_path=test_data_path,
                 cpu_count=cpu_count,
                 batch_size=batch_size,
-                num_sample_ids=num_sample_ids,
                 sample_id=sample_id,
+                num_sample_ids=num_sample_ids,
+                grid_size=grid_size,
+                num_partitions=num_partitions,
+            )
+        ],
+        **kwargs,
+    )
+
+
+def embed_with_mask(
+    input_path: Annotated[str, typer.Argument(help="Input root directory")],
+    output_path: Annotated[str, typer.Argument(help="Output root directory")],
+    test_data_path: Annotated[str, typer.Argument(help="Test DataFrame directory")],
+    cpu_count: Annotated[int, typer.Option(help="Number of CPUs")] = 4,
+    batch_size: Annotated[int, typer.Option(help="Batch size")] = 32,
+    sample_id: Annotated[int, typer.Option(help="Sample ID")] = None,
+    num_sample_ids: Annotated[int, typer.Option(help="Number of sample IDs")] = 20,
+    grid_size: Annotated[int, typer.Option(help="Grid size")] = 4,
+    num_partitions: Annotated[int, typer.Option(help="Number of partitions")] = 10,
+    scheduler_host: Annotated[str, typer.Option(help="Scheduler host")] = None,
+):
+    # run the workflow
+    kwargs = {}
+    if scheduler_host:
+        kwargs["scheduler_host"] = scheduler_host
+    else:
+        kwargs["local_scheduler"] = True
+
+    luigi.build(
+        [
+            ProcessEmbeddingsWithMask(
+                input_path=input_path,
+                output_path=output_path,
+                test_data_path=test_data_path,
+                cpu_count=cpu_count,
+                batch_size=batch_size,
+                sample_id=sample_id,
+                num_sample_ids=num_sample_ids,
                 grid_size=grid_size,
                 num_partitions=num_partitions,
             )

--- a/tests/masking/test_mask_workflow.py
+++ b/tests/masking/test_mask_workflow.py
@@ -28,7 +28,6 @@ def test_process_masking(spark, temp_parquet, tmp_path):
         input_path=temp_parquet.as_posix(),
         output_path=output.as_posix(),
         cpu_count=4,
-        batch_size=1,
         num_partitions=1,
         sample_id=0,
         num_sample_ids=1,

--- a/tests/retrieval/test_embed_transform.py
+++ b/tests/retrieval/test_embed_transform.py
@@ -27,8 +27,8 @@ def test_embedder_finetuned_dinov2(
         output_cols=["cls_embedding"],
         model_path=setup_fine_tuned_model(),
         model_name=model_name,
-        batch_size=1,
         grid_size=grid_size,
+        use_grid=True,
     )
     transformed = model.transform(df)
     df_output_cols = ", ".join(model.getOutputCols())


### PR DESCRIPTION
The previous logic was complex. This reverts the transform to the original code, and then modifies the workflow so that there is another column that determines which type the tile is part of. 

This is a WIP, the tests still need to get fixed here.